### PR TITLE
Dockerize Rat Bot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+FROM python:slim
+
+WORKDIR /usr/src/ratty
+
+# Set up a virtualenv.
+# This suppresses an error from pip about running pip as root.
+# This method was pulled from here: https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
+ENV VIRT_ENV=/usr/src/ratty/env
+RUN python3 -m venv $VIRT_ENV
+ENV PATH="$VIRT_ENV/bin:$PATH"
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY rat_bot.py .
+
+CMD [ "python3", "rat_bot.py" ]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Includes words that contain **rat** and **r a t**!
 
 The current Rat Bot install uses Python 3.6, so you will need to install Python 3.6 before doing this.
 
+> Your python command may be different than mentioned here. It could be `python`, `python3`, or `python3.X` (with x being the minor version.)
+
 It's recommended to run Rat Bot in a virtual environment. To do this, run `python3.6 -m venv env` and then activate the virtual environment.
 
 ## Installing
@@ -26,6 +28,27 @@ pip3 install -r requirements.txt
 # Change the Discord token at the bottom of rat_bot.py.
 python3.6 rat_bot.py # Or, configure start-rat.sh.
 ```
+
+## Running in Docker
+
+Rat Bot can be run in Docker using the provided `Dockerfile`. A number of utility scripts are included in the `utils/` folder to aid in this.
+
+First, build Rat Bot: `bash ./utils/build-ratty.sh`
+This step builds the Docker image for Rat Bot and is required before you're able to run it. The image will be tagged as `ratbot/ratbot:latest`.
+
+> Before you do this step, make sure you've made your `.env` file!
+
+Second, run Rat Bot: `bash ./utils/run-ratty-in-docker.sh`
+
+Rat Bot should now be running in Docker.
+
+### Stopping Rat Bot
+Run the stop script: `bash ./utils/stop-ratty-docker.sh`.
+
+### Removing Rat Bot from Docker
+> Either run this command as sudo, or add your user to the `docker` group.
+
+You can remove the Rat Bot container by running the following command: `docker rm ratbot`.
 
 ## Installing as a Service (Linux, `systemd`)
 

--- a/utils/build-ratty.sh
+++ b/utils/build-ratty.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# This builds Rat Bot using the provided Dockerfile.
+
+# Check if Docker exists.
+if ! [ -x "$(command -v docker)" ]; then
+    echo 'Error: Docker is not installed or is not in your PATH.' >&2
+    exit 1
+fi
+
+echo "Building Rat Bot and tagging as ratbot/ratbot:latest."
+set -e -x # Exit on error, print commands as run
+
+docker build . -t ratbot/ratbot:latest

--- a/utils/run-ratty-in-docker.sh
+++ b/utils/run-ratty-in-docker.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run Rat Bot in the Docker container.
+# This also checks if .env is present in the folder as we pass that for the token.
+
+if ! [ -s ".env" ]; then
+    echo "Error: .env file must be present. Run `cp .env.example .env` and put in your bot token." >&2
+    exit 1
+fi
+
+echo "Running Rat Bot in Docker."
+docker run --env-file .env -d --name "ratbot" ratbot/ratbot:latest

--- a/utils/stop-ratty-docker.sh
+++ b/utils/stop-ratty-docker.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Kills an already existing Rat Bot instance in Docker.
+
+set -e -x
+
+docker inspect --format="{{.State.Running}}" ratbot
+
+if [ $? -eq 0 ]; then
+    echo "ratbot exists, stopping in Docker..."
+    docker stop ratbot
+else
+    echo "Error: ratbot isn't running in Docker."
+    exit 1
+fi


### PR DESCRIPTION
This adds a Dockerfile to run Rat Bot in a Docker container instead of on the host. It also adds some documentation to the `README` to help with running Rat Bot in a Docker container.