### PR TITLE
Fix variable name inconsistency

### DIFF
--- a/rat_bot.py
+++ b/rat_bot.py
@@ -14,7 +14,7 @@ activity_type = discord.ActivityType.listening
 activity_name = "squeaks"
 activity = discord.Activity(type=activity_type, name=activity_name)
 
-admin = getenv("ADMIN_ID")  # User ID for admin user
+admin_id = getenv("ADMIN_ID")  # User ID for admin user
 bot_id = getenv("BOT_ID")  # User ID for the bot
 
 ball_choices = (
@@ -81,7 +81,7 @@ async def on_message(message):
         except Exception:
             await message.channel.send(
                 "Squeek squeek... "
-                f"(Something went wrong, make {admin} fix it...)",
+                f"(Something went wrong, make <@{admin_id}> fix it...)",
                 mention_author=True,
                 reference=message
             )


### PR DESCRIPTION
This renames `admin` to `admin_id` to be more consistent with the naming of the `bot_id` variable.

This also fixes a bug (maybe it wasn't a bug... who knows) which would just make the bot print out the contents of the `ADMIN_ID` environment variable instead of mentioning the admin if an error condition occurred in the oracle command.